### PR TITLE
Parse variable/constant parameters

### DIFF
--- a/lib/parser/parser-base.ts
+++ b/lib/parser/parser-base.ts
@@ -81,7 +81,8 @@ export class ParserBase {
           this.advanceWhitespace();
         }
       } else {
-        if (this.getNextWord({ consume: false }).toLowerCase() === 'signal' || this.getNextWord({ consume: false }).toLowerCase() === 'file') {
+        const next = this.getNextWord({ consume: false }).toLowerCase();
+        if (next === 'signal' || next === 'variable' || next === 'constant' || next === 'file') {
           this.getNextWord();
         }
         port.name = new OName(port, this.pos.i, this.pos.i);


### PR DESCRIPTION
[Procedure parameters can be `signal`, `variable` or `constant`](https://www.ics.uci.edu/~jmoorkan/vhdlref/procedur.html).

`variable` parameters appear e.g. in [`math_real.vhdl`](https://github.com/g0t00/vhdl-linter/blob/vscode/ieee2008/math_real.vhdl#L215), which broke the parser on that file.