### PR TITLE
Fix description for preferred logic type parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
 						"std_ulogic"
 					],
 					"default": "std_ulogic",
-					"description": "Enables checking for library magic comment."
+					"description": "Preferred logic type (resolved/unresolved) to check for."
 				},
 				"VhdlLinter.style.unusedSignalRegex": {
 					"scope": "window",


### PR DESCRIPTION
This fixes the description for the preferred logic type parameter which currently seems to be a copy & paste residue.