### PR TITLE
Add source field to diagnostics

### DIFF
--- a/lib/language-server.ts
+++ b/lib/language-server.ts
@@ -241,6 +241,7 @@ async function validateTextDocument(textDocument: TextDocument, cancelationObjec
   // start = Date.now();
   try {
     const diagnostics = await vhdlLinter.checkAll();
+    diagnostics.forEach((diag, _) => diag.source = "vhdl-linter");
     // console.log(`checked for: ${Date.now() - start} ms.`);
     // start = Date.now();
     const test = JSON.stringify(diagnostics);


### PR DESCRIPTION
By setting the source field for all diagnostics, the user can determine on first glance that a message is generated by the linter. This is especially helpful when several extensions are running and generating messages for a document.

Before:
![image](https://user-images.githubusercontent.com/33267536/193869958-83e31b25-5517-4d1d-aaeb-e224e7cff97d.png)

After:
![image](https://user-images.githubusercontent.com/33267536/193870024-a1a102f3-1e5e-4545-9020-cd3b345f1bd6.png)
